### PR TITLE
[Refinement] Fix Memory Issues

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -73,3 +73,52 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --build-config ${{ matrix.build_type }}
+
+    - name: Valgrind Memcheck
+      if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
+      run: |
+        sudo apt-get install -y valgrind
+        failed=''; total=0; passed=0
+        for t in $(find ${{ steps.strings.outputs.build-output-dir }}/tests \
+                        -maxdepth 1 -name 'test_*' -executable -type f | sort); do
+          name=$(basename "$t"); total=$((total + 1))
+          printf '\n=== memcheck: %s ===\n' "$name"
+          if valgrind --leak-check=full --error-exitcode=1 "$t"; then
+            printf '[PASS] %s\n' "$name"; passed=$((passed + 1))
+          else
+            printf '[FAIL] %s\n' "$name"; failed="${failed:+$failed }$name"
+          fi
+        done
+        printf '\nmemcheck: %d/%d passed\n' "$passed" "$total"
+        if [ -n "$failed" ]; then printf 'FAILURES: %s\n' "$failed" >&2; exit 1; fi
+
+    - name: Configure ASan build
+      if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
+      run: >
+        cmake -B ${{ github.workspace }}/build-asan
+        -DCMAKE_C_COMPILER=gcc
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
+        -DENABLE_TESTS=true
+        -S ${{ github.workspace }}
+
+    - name: Build ASan
+      if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
+      run: cmake --build ${{ github.workspace }}/build-asan
+
+    - name: Run ASan tests
+      if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
+      run: |
+        failed=''; total=0; passed=0
+        for t in $(find ${{ github.workspace }}/build-asan/tests \
+                        -maxdepth 1 -name 'test_*' -executable -type f | sort); do
+          name=$(basename "$t"); total=$((total + 1))
+          printf '\n=== asan: %s ===\n' "$name"
+          if ASAN_OPTIONS=detect_leaks=1 "$t"; then
+            printf '[PASS] %s\n' "$name"; passed=$((passed + 1))
+          else
+            printf '[FAIL] %s\n' "$name"; failed="${failed:+$failed }$name"
+          fi
+        done
+        printf '\nasan: %d/%d passed\n' "$passed" "$total"
+        if [ -n "$failed" ]; then printf 'FAILURES: %s\n' "$failed" >&2; exit 1; fi

--- a/lib/include/cutil/string/builder.h
+++ b/lib/include/cutil/string/builder.h
@@ -172,6 +172,41 @@ char *
 cutil_StringBuilder_duplicate_string(const cutil_StringBuilder *sb);
 
 /**
+ * Copies string in `sb` to buffer `buf` whose size is `buflen`. If the buffer
+ * is too small, no action is performed.
+ *
+ * @param[in] sb cutil_StringBuilder to get string of
+ * @param[in] buflen size of buffer
+ * @param[in, out] buf buffer to write string to
+ *
+ * @return length of copied string (without NUL character) or 0 if buffer is too
+ * small
+ */
+size_t
+cutil_StringBuilder_copy_string_to_buf(
+  const cutil_StringBuilder *sb, size_t buflen, char *buf
+);
+
+/**
+ * Copies string in `sb` to buffer pointed to by `p_buf` whose size is pointed
+ * to by `p_buflen` and performs potentially necessary (re)allocations. If any
+ * (re)allocation happens and `p_buflen` is not NULL, the new size of the buffer
+ * (including the NUL character) is written to *`p_buflen`. *`p_buf` needs to be
+ * freed.
+ *
+ * @param[in] sb cutil_StringBuilder to get string of
+ * @param[in, out] p_buflen pointer to length of buffer to write new length to
+ * (if it is not NULL)
+ * @param[in, out] p_buf pointer to buffer to write string to
+ *
+ * @return length of copied string (without NUL character)
+ */
+size_t
+cutil_StringBuilder_copy_string(
+  const cutil_StringBuilder *sb, size_t *p_buflen, char **p_buf
+);
+
+/**
  * Inserts va_list `args` according to printf-like format string `format` to
  * `sb` at position `pos` up to at most `maxlen` bytes.
  *

--- a/lib/include/cutil/string/builder.h
+++ b/lib/include/cutil/string/builder.h
@@ -10,7 +10,6 @@
 #include <stdarg.h>
 
 #include <cutil/cutil.h>
-#include <cutil/std/stdio.h>
 #include <cutil/std/stdlib.h>
 
 #ifdef __cplusplus
@@ -18,7 +17,11 @@ extern "C" {
 #endif
 
 /**
- * String builder
+ * String builder.
+ *
+ * NUL-terminator invariant: @c str[length] == '\0' is maintained after every
+ * operation. @c length counts stored characters and excludes the NUL
+ * terminator; @c capacity >= length + 1.
  */
 typedef struct {
     size_t capacity;
@@ -39,7 +42,7 @@ enum {
 
 /**
  * Creates newly malloc'd cutil_StringBuilder object with default initial
- * capacity.
+ * capacity. The string is initialized to an empty NUL-terminated string.
  *
  * @return newly malloc'd cutil_StringBuilder object
  */
@@ -48,7 +51,7 @@ cutil_StringBuilder_create(void);
 
 /**
  * Creates newly malloc'd cutil_StringBuilder object with initial capacity
- * `size`.
+ * `size`. The string is initialized to an empty NUL-terminated string.
  *
  * @param[in] size initial capacity (0 for default)
  *
@@ -59,6 +62,7 @@ cutil_StringBuilder_alloc(size_t size);
 
 /**
  * Reads contents of `str` into newly malloc'd cutil_StringBuilder object.
+ * The resulting builder contains a NUL-terminated copy of `str`.
  *
  * @param[in] str string to read data from
  *
@@ -68,18 +72,8 @@ cutil_StringBuilder *
 cutil_StringBuilder_from_string(const char *str);
 
 /**
- * Reads contents of `in` into newly malloc'd cutil_StringBuilder object.
- *
- * @param[in] in FILE stream to read data from
- *
- * @return newly malloc'd cutil_StringBuilder object with contents of `in` (NULL
- * for error)
- */
-cutil_StringBuilder *
-cutil_StringBuilder_from_file(FILE *in);
-
-/**
  * Copies contents of `sb` into newly malloc'd cutil_StringBuilder object.
+ * The NUL-terminator invariant is preserved in the duplicate.
  *
  * @param[in] sb cutil_StringBuilder to copy data of
  *
@@ -97,7 +91,8 @@ void
 cutil_StringBuilder_free(cutil_StringBuilder *sb);
 
 /**
- * Clears contents of `sb` and resets sizes.
+ * Clears contents of `sb` and resets sizes. The NUL-terminator invariant
+ * is preserved: after this call @c sb->str[0] == '\0' and @c length == 0.
  *
  * @param[in] sb cutil_StringBuilder object to clear
  */
@@ -105,7 +100,8 @@ void
 cutil_StringBuilder_clear(cutil_StringBuilder *sb);
 
 /**
- * Copies contents of `src` into `dst`.
+ * Copies contents of `src` into `dst`. The NUL-terminator invariant is
+ * preserved in the destination.
  *
  * @param[in, out] dst cutil_StringBuilder to copy data into
  * @param[in] src cutil_StringBuilder to copy data of
@@ -117,7 +113,8 @@ cutil_StringBuilder_copy(
 
 /**
  * Manually resizes (and potentially truncates) string and/or buffer inside `sb`
- * to new size `target` according to `flags`.
+ * to new size `target` according to `flags`. When the string is truncated the
+ * NUL-terminator is placed at the new @c length position.
  *
  * @param[in] sb cutil_StringBuilder to resize
  * @param[in] target target size of string and buffer
@@ -127,8 +124,9 @@ void
 cutil_StringBuilder_resize(cutil_StringBuilder *sb, size_t target, int flags);
 
 /**
- * Manually resizes string and buffer inside `sb` to exatcly to current size.
- * This overrides standard resize algorithm.
+ * Manually resizes string and buffer inside `sb` to exactly the current size.
+ * This overrides the standard resize algorithm. The NUL-terminator invariant
+ * is preserved.
  *
  * @param[in] sb cutil_StringBuilder to shrink to fit
  */
@@ -136,11 +134,12 @@ void
 cutil_StringBuilder_shrink_to_fit(cutil_StringBuilder *sb);
 
 /**
- * Returns length of string in `sb`.
+ * Returns the number of characters stored in `sb`, excluding the NUL
+ * terminator. Equivalent to @c strlen(cutil_StringBuilder_get_string(sb)).
  *
  * @param[in] sb cutil_StringBuilder to get length of
  *
- * @return length of string in `sb`
+ * @return number of stored characters, excluding the NUL terminator
  */
 inline size_t
 cutil_StringBuilder_length(const cutil_StringBuilder *sb)
@@ -149,11 +148,12 @@ cutil_StringBuilder_length(const cutil_StringBuilder *sb)
 }
 
 /**
- * Returns string in `sb`.
+ * Returns the NUL-terminated string stored in `sb`. The pointer is owned by
+ * the builder and remains valid until the next mutating call.
  *
  * @param[in] sb cutil_StringBuilder to get string of
  *
- * @return string in `sb`
+ * @return NUL-terminated string owned by @c sb
  */
 inline const char *
 cutil_StringBuilder_get_string(const cutil_StringBuilder *sb)
@@ -162,25 +162,27 @@ cutil_StringBuilder_get_string(const cutil_StringBuilder *sb)
 }
 
 /**
- * Returns newly malloc'd copy of string in `sb`. Has to be freed.
+ * Returns a newly malloc'd NUL-terminated copy of the string in `sb`. The
+ * caller is responsible for freeing the returned pointer.
  *
  * @param[in] sb cutil_StringBuilder to get string of
  *
- * @return string in `sb`
+ * @return newly malloc'd NUL-terminated copy of the string; caller must free
  */
 char *
 cutil_StringBuilder_duplicate_string(const cutil_StringBuilder *sb);
 
 /**
- * Copies string in `sb` to buffer `buf` whose size is `buflen`. If the buffer
- * is too small, no action is performed.
+ * Copies the NUL-terminated string in `sb` to buffer `buf` of size `buflen`.
+ * If the buffer is too small (buflen < length + 1), no action is performed.
+ * On success the buffer is NUL-terminated.
  *
  * @param[in] sb cutil_StringBuilder to get string of
- * @param[in] buflen size of buffer
- * @param[in, out] buf buffer to write string to
+ * @param[in] buflen size of buffer (must be >= length + 1 for success)
+ * @param[in, out] buf buffer to write NUL-terminated string to
  *
- * @return length of copied string (without NUL character) or 0 if buffer is too
- * small
+ * @return length of copied string (without NUL character) or 0 if buffer is
+ * too small
  */
 size_t
 cutil_StringBuilder_copy_string_to_buf(
@@ -417,6 +419,8 @@ cutil_StringBuilder_append(
 
 /**
  * Deletes `num` chars from the string in `sb` starting at `pos` (inclusively).
+ * The NUL-terminator invariant is preserved: @c sb->str[sb->length] == '\0'
+ * after the call.
  *
  * @param[in] sb cutil_StringBuilder to delete from
  * @param[in] pos position to start deletion at
@@ -427,7 +431,7 @@ cutil_StringBuilder_delete(cutil_StringBuilder *sb, size_t pos, size_t num);
 
 /**
  * Deletes all chars between `begin` and `end` (inclusively) from the string in
- * `sb` starting at `pos.
+ * `sb`. The NUL-terminator invariant is preserved.
  *
  * @param[in] sb cutil_StringBuilder to delete from
  * @param[in] begin position of the first char to delete

--- a/lib/src/string/builder.c
+++ b/lib/src/string/builder.c
@@ -2,6 +2,7 @@
 
 #include <cutil/cutil.h>
 #include <cutil/debug/null.h>
+#include <cutil/io/log.h>
 #include <cutil/std/math.h>
 #include <cutil/std/stdbool.h>
 #include <cutil/std/stdio.h>
@@ -237,6 +238,43 @@ cutil_StringBuilder_duplicate_string(const cutil_StringBuilder *sb)
     char *const cpy = malloc(len * sizeof *cpy);
     memcpy(cpy, sb->str, len * sizeof *cpy);
     return cpy;
+}
+
+size_t
+cutil_StringBuilder_copy_string_to_buf(
+  const cutil_StringBuilder *sb, size_t buflen, char *buf
+)
+{
+    CUTIL_NULL_CHECK(sb);
+    CUTIL_NULL_CHECK(buf);
+    const size_t len = sb->length + 1;
+    if (buflen < len) {
+        cutil_log_error("Cannot copy string: buffer too small");
+        return 0;
+    }
+    memcpy(buf, sb->str, len * sizeof *buf);
+    return sb->length;
+}
+
+size_t
+cutil_StringBuilder_copy_string(
+  const cutil_StringBuilder *sb, size_t *p_buflen, char **p_buf
+)
+{
+    CUTIL_NULL_CHECK(sb);
+    CUTIL_NULL_CHECK(p_buf);
+    const size_t len = sb->length + 1;
+    const size_t buflen = (p_buflen == NULL) ? 0 : *p_buflen;
+    if (p_buflen != NULL && buflen < len) {
+        *p_buflen = len;
+    }
+    if (*p_buf == NULL) {
+        *p_buf = malloc(len * sizeof **p_buf);
+    } else if (buflen < len) {
+        *p_buf = realloc(*p_buf, len * sizeof **p_buf);
+    }
+    memcpy(*p_buf, sb->str, len * sizeof **p_buf);
+    return sb->length;
 }
 
 int

--- a/lib/src/string/builder.c
+++ b/lib/src/string/builder.c
@@ -112,29 +112,6 @@ cutil_StringBuilder_from_string(const char *str)
 }
 
 cutil_StringBuilder *
-cutil_StringBuilder_from_file(FILE *in)
-{
-    CUTIL_NULL_CHECK(in);
-
-    const size_t fsize = (size_t) cutil_get_filesize(in);
-    cutil_StringBuilder *const sb = cutil_StringBuilder_alloc(fsize);
-
-    rewind(in);
-    const size_t size = fread(sb->str, 1UL, fsize, in);
-    if (size != fsize - 1) {
-        cutil_StringBuilder_free(sb);
-        return NULL;
-    }
-    /**
-     * TODO: Not optimal, probably need another object to read stuff from files
-     * to prevent potential '\0' characters from breaking things.
-     */
-    sb->length = strlen(sb->str);
-
-    return sb;
-}
-
-cutil_StringBuilder *
 cutil_StringBuilder_duplicate(const cutil_StringBuilder *sb)
 {
     CUTIL_NULL_CHECK(sb);
@@ -461,7 +438,7 @@ cutil_StringBuilder_delete(cutil_StringBuilder *sb, size_t pos, size_t num)
     if (pos + num > sb->length) {
         num = sb->length - pos;
     }
-    memmove(&sb->str[pos], &sb->str[pos + num], num);
+    memmove(&sb->str[pos], &sb->str[pos + num], sb->length - pos - num + 1);
     sb->length -= num;
 }
 

--- a/lib/src/string/builder.c
+++ b/lib/src/string/builder.c
@@ -146,7 +146,7 @@ cutil_StringBuilder_duplicate(const cutil_StringBuilder *sb)
     dup->bufsiz = sb->bufsiz;
     dup->buf = malloc(dup->bufsiz * sizeof *dup->buf);
 
-    memcpy(dup->str, sb->str, sb->length);
+    memcpy(dup->str, sb->str, sb->length + 1);
 
     return dup;
 }
@@ -178,12 +178,12 @@ cutil_StringBuilder_copy(
     CUTIL_NULL_CHECK(src);
 
     dst->capacity = src->capacity;
-    dst->str = realloc(src->str, src->capacity * sizeof *src->str);
+    dst->str = realloc(dst->str, src->capacity * sizeof *dst->str);
     dst->length = src->length;
     dst->bufsiz = src->bufsiz;
-    dst->buf = realloc(src->buf, src->bufsiz * sizeof *src->buf);
+    dst->buf = realloc(dst->buf, src->bufsiz * sizeof *dst->buf);
 
-    memcpy(dst->str, src->str, src->length);
+    memcpy(dst->str, src->str, src->length + 1);
 }
 
 void
@@ -196,6 +196,13 @@ cutil_StringBuilder_resize(cutil_StringBuilder *sb, size_t target, int flags)
           &sb->str, &sb->capacity, STRING_THRESHOLD_SIZE, target, force
         );
         if (sb->length >= target) {
+            if (force) {
+                /* Grow by one to fit the null terminator after the truncated
+                 * text */
+                sb->str
+                  = realloc(sb->str, (sb->capacity + 1) * sizeof *sb->str);
+                ++sb->capacity;
+            }
             sb->length = target;
             sb->str[sb->length] = '\0';
         }

--- a/tests/io/test_log.c
+++ b/tests/io/test_log.c
@@ -1,6 +1,11 @@
+/* Request POSIX.1-2008 for fileno() and read() */
+#define _POSIX_C_SOURCE 200809L
+
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "unity.h"
 
@@ -191,10 +196,14 @@ _should_autoCloseStream_when_destroyLogger(void)
     cutil_Logger_add_handler(log, stream, CUTIL_LOG_INFO);
 
     /* Act */
+    const int fd = fileno(stream);
     cutil_Logger_free(log);
 
-    /* Assert */
-    TEST_ASSERT_EQUAL(EOF, fgetc(stream));
+    /* Assert — fd must be closed (EBADF on read) */
+    char buf[1];
+    errno = 0;
+    TEST_ASSERT_EQUAL(-1, read(fd, buf, sizeof buf));
+    TEST_ASSERT_EQUAL(EBADF, errno);
 }
 
 void

--- a/tests/io/test_log.c
+++ b/tests/io/test_log.c
@@ -1,5 +1,7 @@
-/* Request POSIX.1-2008 for fileno() and read() */
-#define _POSIX_C_SOURCE 200809L
+/* Request POSIX.1-1993 for fileno() and read() */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 199309L
+#endif /* _POSIX_C_SOURCE */
 
 #include <errno.h>
 #include <stdbool.h>

--- a/tests/string/test_builder.c
+++ b/tests/string/test_builder.c
@@ -48,21 +48,16 @@ _should_constructBuilder_when_useString(void)
 }
 
 static void
-_should_constructBuilder_when_useFile(void)
+_should_preserveNulInvariant_when_constructEmpty(void)
 {
-    /* Arrange */
-    const char *const assert_str = LONG_STRING;
-    FILE *const in = tmpfile();
-    fwrite(assert_str, 1UL, sizeof LONG_STRING, in);
-
     /* Act */
-    cutil_StringBuilder *const sb = cutil_StringBuilder_from_file(in);
+    cutil_StringBuilder *const sb = cutil_StringBuilder_alloc(0);
 
-    /* Assert */
+    /* Assert: invariant str[length] == '\0' on an empty builder */
     const size_t len = cutil_StringBuilder_length(sb);
-    TEST_ASSERT_EQUAL_size_t(strlen(assert_str), len);
+    TEST_ASSERT_EQUAL_size_t(0, len);
     const char *const str = cutil_StringBuilder_get_string(sb);
-    TEST_ASSERT_EQUAL_STRING(assert_str, str);
+    TEST_ASSERT_EQUAL_CHAR('\0', str[len]);
 
     /* Cleanup */
     cutil_StringBuilder_free(sb);
@@ -277,6 +272,8 @@ _should_insertCorrectly(void)
     TEST_ASSERT_EQUAL_size_t(strlen(assert_str), len);
     const char *const str = cutil_StringBuilder_get_string(sb);
     TEST_ASSERT_EQUAL_STRING(assert_str, str);
+    /* Invariant: str[length] must be NUL after middle insert */
+    TEST_ASSERT_EQUAL_CHAR('\0', str[len]);
 
     /* Cleanup */
     cutil_StringBuilder_free(sb);
@@ -432,6 +429,8 @@ _should_duplicateStringCorrectly(void)
 
     /* Assert */
     TEST_ASSERT_EQUAL_STRING(assert_str, cpy);
+    /* Invariant: duplicated string is NUL-terminated */
+    TEST_ASSERT_EQUAL_CHAR('\0', cpy[strlen(assert_str)]);
 
     /* Cleanup */
     free(cpy);
@@ -453,6 +452,8 @@ _should_copyStringCorrectly_when_bufferIsLargeEnough(void)
 
     /* Assert */
     TEST_ASSERT_EQUAL_STRING(assert_str, buf);
+    /* Invariant: buf is NUL-terminated on success */
+    TEST_ASSERT_EQUAL_CHAR('\0', buf[len]);
 
     /* Cleanup */
     free(buf);
@@ -572,6 +573,30 @@ _should_deleteCorrectly(void)
 }
 
 static void
+_should_deleteCorrectly_when_numLessThanRemainder(void)
+{
+    /* Arrange: delete 1 char where the remaining suffix (7 chars) exceeds num.
+     * The old memmove(num) bug would fail to move the suffix and NUL. */
+    const char *const input_str = "Hello, World!";
+    const char *const assert_str = "Hello World!";
+    cutil_StringBuilder *const sb = cutil_StringBuilder_from_string(input_str);
+
+    /* Act: delete ',' at pos 5 (num=1, remainder=7 > num) */
+    cutil_StringBuilder_delete(sb, 5, 1);
+
+    /* Assert */
+    const size_t len = cutil_StringBuilder_length(sb);
+    TEST_ASSERT_EQUAL_size_t(strlen(assert_str), len);
+    const char *const str = cutil_StringBuilder_get_string(sb);
+    TEST_ASSERT_EQUAL_STRING(assert_str, str);
+    /* Invariant: str[length] must be NUL — catches the memmove(num) bug */
+    TEST_ASSERT_EQUAL_CHAR('\0', str[len]);
+
+    /* Cleanup */
+    cutil_StringBuilder_free(sb);
+}
+
+static void
 _should_deleteCorrectly_when_boundsExceedSize(void)
 {
     /* Arrange */
@@ -648,7 +673,7 @@ main(void)
     UNITY_BEGIN();
     RUN_TEST(_should_constructBuilder_when_useSize);
     RUN_TEST(_should_constructBuilder_when_useString);
-    RUN_TEST(_should_constructBuilder_when_useFile);
+    RUN_TEST(_should_preserveNulInvariant_when_constructEmpty);
     RUN_TEST(_should_duplicateBuilder);
     RUN_TEST(_should_clearCorrectly);
     RUN_TEST(_should_copyCorrectly);
@@ -670,6 +695,7 @@ main(void)
     RUN_TEST(_should_copyStringAndRetainPointer_when_bufferIsLargeEnough);
     RUN_TEST(_should_copyStringCorrectly_when_buflenIsNull);
     RUN_TEST(_should_deleteCorrectly);
+    RUN_TEST(_should_deleteCorrectly_when_numLessThanRemainder);
     RUN_TEST(_should_deleteCorrectly_when_boundsExceedSize);
     RUN_TEST(_should_deleteCorrectly_when_useFromTo);
     RUN_TEST(_should_deleteFromToCorrectly_when_boundsExceedSize);

--- a/tests/string/test_builder.c
+++ b/tests/string/test_builder.c
@@ -90,6 +90,7 @@ _should_duplicateBuilder(void)
     TEST_ASSERT_EQUAL_size_t(sb_assert->bufsiz, sb->bufsiz);
 
     /* Cleanup */
+    cutil_StringBuilder_free(sb_assert);
     cutil_StringBuilder_free(sb);
 }
 
@@ -116,6 +117,7 @@ _should_clearCorrectly(void)
     TEST_ASSERT_EQUAL_size_t(sb_assert->capacity, sb->capacity);
 
     /* Cleanup */
+    cutil_StringBuilder_free(sb_assert);
     cutil_StringBuilder_free(sb);
 }
 
@@ -143,6 +145,7 @@ _should_copyCorrectly(void)
     TEST_ASSERT_EQUAL_size_t(sb_assert->bufsiz, sb->bufsiz);
 
     /* Cleanup */
+    cutil_StringBuilder_free(sb_assert);
     cutil_StringBuilder_free(sb);
 }
 
@@ -325,7 +328,9 @@ _should_shrinkCorrectly_when_resizeWithForce(void)
 
         /* Assert */
         TEST_ASSERT_EQUAL_size_t(size, cutil_StringBuilder_length(sb));
-        TEST_ASSERT_EQUAL_size_t(size, sb->capacity);
+        /* capacity = size + 1: resize allocates one extra byte for null
+         * terminator */
+        TEST_ASSERT_EQUAL_size_t(size + 1, sb->capacity);
         TEST_ASSERT_EQUAL_size_t(size, sb->bufsiz);
     }
 

--- a/tests/string/test_builder.c
+++ b/tests/string/test_builder.c
@@ -2,6 +2,7 @@
 
 #include "unity.h"
 
+#include <cutil/std/string.h>
 #include <cutil/string/builder.h>
 
 #define LONG_STRING                                                            \
@@ -438,6 +439,118 @@ _should_duplicateStringCorrectly(void)
 }
 
 static void
+_should_copyStringCorrectly_when_bufferIsLargeEnough(void)
+{
+    /* Arrange */
+    const char assert_str[] = "Hello, World!";
+    cutil_StringBuilder *const sb = cutil_StringBuilder_from_string(assert_str);
+    const size_t buflen = sizeof assert_str;
+    char *const buf = malloc(buflen * sizeof *buf);
+
+    /* Act */
+    const size_t len = cutil_StringBuilder_copy_string_to_buf(sb, buflen, buf);
+    TEST_ASSERT_EQUAL_size_t(buflen - 1, len);
+
+    /* Assert */
+    TEST_ASSERT_EQUAL_STRING(assert_str, buf);
+
+    /* Cleanup */
+    free(buf);
+    cutil_StringBuilder_free(sb);
+}
+
+static void
+_should_notCopyString_when_bufferIsTooSmall(void)
+{
+    /* Arrange */
+    const char *const assert_str = "Hello, World!";
+    cutil_StringBuilder *const sb = cutil_StringBuilder_from_string(assert_str);
+
+    const char small_str[] = "Hello";
+    const size_t buflen = sizeof small_str;
+    char *const buf = cutil_strdup(small_str);
+
+    /* Act */
+    const size_t len = cutil_StringBuilder_copy_string_to_buf(sb, buflen, buf);
+
+    /* Assert */
+    TEST_ASSERT_EQUAL_STRING(small_str, buf);
+    TEST_ASSERT_EQUAL_size_t(0, len);
+
+    /* Cleanup */
+    free(buf);
+    cutil_StringBuilder_free(sb);
+}
+
+static void
+_should_copyStringCorrectly_when_bufferIsNull(void)
+{
+    /* Arrange */
+    const char assert_str[] = "Hello, World!";
+    cutil_StringBuilder *const sb = cutil_StringBuilder_from_string(assert_str);
+    size_t buflen = 0;
+    char *buf = NULL;
+
+    /* Act */
+    const size_t newlen = cutil_StringBuilder_copy_string(sb, &buflen, &buf);
+
+    /* Assert */
+    TEST_ASSERT_EQUAL_STRING(assert_str, buf);
+    TEST_ASSERT_EQUAL_size_t(sizeof assert_str, buflen);
+    TEST_ASSERT_EQUAL_size_t(sizeof assert_str - 1, newlen);
+
+    /* Cleanup */
+    free(buf);
+    cutil_StringBuilder_free(sb);
+}
+
+static void
+_should_copyStringAndRetainPointer_when_bufferIsLargeEnough(void)
+{
+    /* Arrange */
+    const char assert_str[] = "Hello, World!";
+    cutil_StringBuilder *const sb = cutil_StringBuilder_from_string(assert_str);
+
+    size_t buflen = sizeof assert_str + 1;
+    char *buf = malloc(buflen * sizeof *buf);
+    char *const old_buf = buf;
+    const size_t old_buflen = buflen;
+
+    /* Act */
+    const size_t newlen = cutil_StringBuilder_copy_string(sb, &buflen, &buf);
+
+    /* Assert */
+    TEST_ASSERT_EQUAL_STRING(assert_str, buf);
+    TEST_ASSERT_EQUAL_PTR(old_buf, buf);
+    TEST_ASSERT_EQUAL_size_t(old_buflen, buflen);
+    TEST_ASSERT_EQUAL_size_t(sizeof assert_str - 1, newlen);
+
+    /* Cleanup */
+    free(buf);
+    cutil_StringBuilder_free(sb);
+}
+
+static void
+_should_copyStringCorrectly_when_buflenIsNull(void)
+{
+    /* Arrange */
+    const char assert_str[] = "Hello, World!";
+    cutil_StringBuilder *const sb = cutil_StringBuilder_from_string(assert_str);
+    char *buf = NULL;
+
+    /* Act */
+    const size_t newlen = cutil_StringBuilder_copy_string(sb, NULL, &buf);
+
+    /* Assert */
+    TEST_ASSERT_EQUAL_STRING(assert_str, buf);
+    TEST_ASSERT_EQUAL_size_t(sizeof assert_str - 1, newlen);
+
+    /* Cleanup */
+    free(buf);
+    cutil_StringBuilder_free(sb);
+}
+
+static void
 _should_deleteCorrectly(void)
 {
     /* Arrange */
@@ -551,6 +664,11 @@ main(void)
     RUN_TEST(_should_expandCorrectly_when_resizeWithForce);
     RUN_TEST(_should_resizeCorrectly_when_shrinkToFit);
     RUN_TEST(_should_duplicateStringCorrectly);
+    RUN_TEST(_should_copyStringCorrectly_when_bufferIsLargeEnough);
+    RUN_TEST(_should_notCopyString_when_bufferIsTooSmall);
+    RUN_TEST(_should_copyStringCorrectly_when_bufferIsNull);
+    RUN_TEST(_should_copyStringAndRetainPointer_when_bufferIsLargeEnough);
+    RUN_TEST(_should_copyStringCorrectly_when_buflenIsNull);
     RUN_TEST(_should_deleteCorrectly);
     RUN_TEST(_should_deleteCorrectly_when_boundsExceedSize);
     RUN_TEST(_should_deleteCorrectly_when_useFromTo);


### PR DESCRIPTION
# Summary
This PR contains some fixes regarding memory leaks and invalid reads/writes, adds string-copying functions to StringBuilder and clarifies NUL-termination in the documentation and adds memory checks to the GitHub pipeline.

# Changes
- Set unity to fixed version
- Fix memory-related issues
- Add memory checks to GitHub pipeline
- Add string-copying functions to StringBuilder
- Clarify NUL-termination of strings in StringBuilder
- Adjust unit tests accordingly