### PR TITLE
[Refinement] Add Test for C++ Compilation and Fix Issues

### DIFF
--- a/lib/include/cutil/data/generic/list.h
+++ b/lib/include/cutil/data/generic/list.h
@@ -168,7 +168,7 @@ cutil_List_duplicate(const cutil_List *list)
     CUTIL_NULL_CHECKS_LIST(list);
     CUTIL_NULL_CHECK_VTABLE(list->vtable, duplicate);
     CUTIL_RETURN_NULL_IF_NULL(list->vtable->duplicate);
-    cutil_List *const dup = CUTIL_MALLOC_OBJECT(dup);
+    cutil_List *const dup = (cutil_List *) CUTIL_MALLOC_OBJECT(dup);
     dup->vtable = list->vtable;
     dup->data = list->vtable->duplicate(list->data);
     return dup;

--- a/lib/include/cutil/data/generic/map.h
+++ b/lib/include/cutil/data/generic/map.h
@@ -86,7 +86,7 @@ cutil_Map_get_vtable(const cutil_Map *map)
 
 /**
  * Frees contents of `map`.
- * 
+ *
  * @param[in] map cutil_Map object to be cleared
  */
 inline void
@@ -161,7 +161,7 @@ cutil_Map_duplicate(const cutil_Map *map)
     CUTIL_NULL_CHECKS_MAP(map);
     CUTIL_NULL_CHECK_VTABLE(map->vtable, duplicate);
     CUTIL_RETURN_NULL_IF_NULL(map->vtable->duplicate);
-    cutil_Map *const dup = CUTIL_MALLOC_OBJECT(dup);
+    cutil_Map *const dup = (cutil_Map *) CUTIL_MALLOC_OBJECT(dup);
     dup->vtable = map->vtable;
     dup->data = map->vtable->duplicate(map->data);
     return dup;
@@ -196,7 +196,7 @@ cutil_Map_remove(cutil_Map *map, const void *key)
 {
     CUTIL_NULL_CHECKS_MAP(map);
     CUTIL_NULL_CHECK_VTABLE(map->vtable, remove);
-    CUTIL_RETURN_VAL_IF_NULL(map->vtable->remove, EXIT_FAILURE);
+    CUTIL_RETURN_VAL_IF_NULL(map->vtable->remove, CUTIL_STATUS_FAILURE);
     return map->vtable->remove(map->data, key);
 }
 

--- a/lib/include/cutil/data/generic/set.h
+++ b/lib/include/cutil/data/generic/set.h
@@ -158,7 +158,7 @@ cutil_Set_duplicate(const cutil_Set *set)
     CUTIL_NULL_CHECKS_SET(set);
     CUTIL_NULL_CHECK_VTABLE(set->vtable, duplicate);
     CUTIL_RETURN_NULL_IF_NULL(set->vtable->duplicate);
-    cutil_Set *const dup = CUTIL_MALLOC_OBJECT(dup);
+    cutil_Set *const dup = (cutil_Set *) CUTIL_MALLOC_OBJECT(dup);
     dup->vtable = set->vtable;
     dup->data = set->vtable->duplicate(set->data);
     return dup;

--- a/lib/include/cutil/data/generic/type.h
+++ b/lib/include/cutil/data/generic/type.h
@@ -63,8 +63,8 @@ inline void
 cutil_void_memswap(void *a, void *b, size_t size)
 {
     char tmp;
-    char *const pa = a;
-    char *const pb = b;
+    char *const pa = (char *) a;
+    char *const pb = (char *) b;
     for (size_t i = 0; i < size; ++i) {
         tmp = pa[i];
         pa[i] = pb[i];

--- a/lib/include/cutil/data/native/bitarray.h
+++ b/lib/include/cutil/data/native/bitarray.h
@@ -106,7 +106,7 @@ cutil_BitArray_get_capacity(const cutil_BitArray *arr)
 inline unsigned char
 cutil_BitArray_get(const cutil_BitArray *arr, size_t idx)
 {
-    const div_t res = div(idx, cutil_BitArray_ELEM_SIZE_IN_BITS);
+    const ldiv_t res = ldiv(idx, cutil_BitArray_ELEM_SIZE_IN_BITS);
     return arr->data[res.quot] & ((unsigned char) 1 << res.rem);
 }
 
@@ -119,7 +119,7 @@ cutil_BitArray_get(const cutil_BitArray *arr, size_t idx)
 inline void
 cutil_BitArray_set(cutil_BitArray *arr, size_t idx)
 {
-    const div_t res = div(idx, cutil_BitArray_ELEM_SIZE_IN_BITS);
+    const ldiv_t res = ldiv(idx, cutil_BitArray_ELEM_SIZE_IN_BITS);
     arr->data[res.quot] |= ((unsigned char) 1 << res.rem);
 }
 
@@ -132,7 +132,7 @@ cutil_BitArray_set(cutil_BitArray *arr, size_t idx)
 inline void
 cutil_BitArray_unset(cutil_BitArray *arr, size_t idx)
 {
-    const div_t res = div(idx, cutil_BitArray_ELEM_SIZE_IN_BITS);
+    const ldiv_t res = ldiv(idx, cutil_BitArray_ELEM_SIZE_IN_BITS);
     arr->data[res.quot] &= ~((unsigned char) 1 << res.rem);
 }
 

--- a/lib/include/cutil/util/compare.h
+++ b/lib/include/cutil/util/compare.h
@@ -57,8 +57,8 @@ cutil_compare_bytes(const void *lhs, const void *rhs, size_t num)
     if (lhs == NULL || rhs == NULL) {
         return CUTIL_DEFAULT_COMPARISON_KERNEL(lhs, rhs);
     }
-    const unsigned char *const a = lhs;
-    const unsigned char *const b = rhs;
+    const unsigned char *const a = (const unsigned char *) lhs;
+    const unsigned char *const b = (const unsigned char *) rhs;
     for (size_t i = 0; i < num; ++i) {
         const unsigned char ai = a[i];
         const unsigned char bi = b[i];
@@ -113,8 +113,8 @@ cutil_compare_sizes(
                                                                                \
     inline int cutil_compare_##ID(const void *lhs, const void *rhs)            \
     {                                                                          \
-        const TYPE *const a = lhs;                                             \
-        const TYPE *const b = rhs;                                             \
+        const TYPE *const a = (const TYPE *) lhs;                              \
+        const TYPE *const b = (const TYPE *) rhs;                              \
         return CUTIL_DEFAULT_COMPARISON_KERNEL(*a, *b);                        \
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+project("CUTIL_TESTS" LANGUAGES C CXX)
+
 # Set additional compiler flags (UNIX)
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 8)
     string(APPEND CMAKE_C_FLAGS " -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/= ")
@@ -21,8 +23,8 @@ else ()
     set(CUTIL_LIB "${CUTIL_LIBRARY}-static")
 endif ()
 
-# Set test source files
-set(TEST_SOURCES
+# Set C test source files
+set(C_TEST_SOURCES
     data/generic/list/test_arraylist.c
     data/generic/map/test_hashmap.c
     data/generic/set/test_hashset.c
@@ -45,8 +47,8 @@ set(TEST_SOURCES
     util/test_hash.c
 )
 
-# Loop over all tests
-foreach (TEST_SOURCE ${TEST_SOURCES})
+# Loop over all C tests
+foreach (TEST_SOURCE ${C_TEST_SOURCES})
     # Derive test name: test_<dir_underscored>_<stem>
     # e.g. data/generic/test_array.c -> test_data_generic_array
     get_filename_component(TEST_DIR "${TEST_SOURCE}" DIRECTORY)
@@ -62,6 +64,34 @@ foreach (TEST_SOURCE ${TEST_SOURCES})
 
     # Link and include Unity
     target_link_libraries("${TEST_NAME}" PRIVATE unity)
+
+    # Link and include cutil
+    target_link_libraries("${TEST_NAME}" PRIVATE "${CUTIL_LIB}")
+endforeach ()
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set C++ test source files
+set(CXX_TEST_SOURCES
+    cpp/test_cpp.cpp
+)
+
+# Loop over all C++ tests
+foreach (TEST_SOURCE ${CXX_TEST_SOURCES})
+    # Derive test name: test_<dir_underscored>_<stem>
+    get_filename_component(TEST_DIR "${TEST_SOURCE}" DIRECTORY)
+    get_filename_component(TEST_BASENAME "${TEST_SOURCE}" NAME_WE)
+    string(REPLACE "/" "_" TEST_DIR_UNDERSCORED "${TEST_DIR}")
+    string(REGEX REPLACE "^test_" "" TEST_STEM "${TEST_BASENAME}")
+    set(TEST_NAME "test_${TEST_DIR_UNDERSCORED}_${TEST_STEM}")
+
+    # Add tests and executables
+    add_executable("${TEST_NAME}" "${TEST_SOURCE}")
+    add_test(NAME "${TEST_NAME}" COMMAND "${TEST_NAME}")
+    list(APPEND CUTIL_TEST_TARGETS "${TEST_NAME}")
 
     # Link and include cutil
     target_link_libraries("${TEST_NAME}" PRIVATE "${CUTIL_LIB}")

--- a/tests/cpp/test_cpp.cpp
+++ b/tests/cpp/test_cpp.cpp
@@ -1,0 +1,48 @@
+#include <cutil/data/generic/list/arraylist.h>
+#include <cutil/data/generic/map/hashmap.h>
+#include <cutil/data/generic/set/hashset.h>
+
+#include <cutil/data/generic/array.h>
+#include <cutil/data/generic/iterator.h>
+#include <cutil/data/generic/list.h>
+#include <cutil/data/generic/map.h>
+#include <cutil/data/generic/object.h>
+#include <cutil/data/generic/set.h>
+#include <cutil/data/generic/type.h>
+#include <cutil/data/native/bitarray.h>
+
+#include <cutil/debug/null.h>
+
+#include <cutil/io/log.h>
+
+#include <cutil/posix/getopt.h>
+
+#include <cutil/std/inttypes.h>
+#include <cutil/std/math.h>
+#include <cutil/std/stdbool.h>
+#include <cutil/std/stddef.h>
+#include <cutil/std/stdio.h>
+#include <cutil/std/stdlib.h>
+#include <cutil/std/string.h>
+
+#include <cutil/string/util/iterator.h>
+
+#include <cutil/string/builder.h>
+#include <cutil/string/type.h>
+
+#include <cutil/util/compare.h>
+#include <cutil/util/hash.h>
+#include <cutil/util/macro.h>
+
+#include <cutil/cutil.h>
+#include <cutil/status.h>
+
+/**
+ * Empty test that includes all cutil headers and just tests whether the C++
+ * compilation succeeds.
+ */
+int
+main()
+{
+    return 0;
+}


### PR DESCRIPTION
# Summary
Fix C++-compilation issues that had previously slipped through. Add unit tests to detect such errors immediately.

# Changes
- Add unit tests to detect C++-compilation errors
- Fix detected issues
