### PR TITLE
[Refinement] Improve CMake Setup

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -52,7 +52,7 @@ jobs:
       id: strings
       shell: bash
       run: |
-        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        echo "build-output-dir=${{ github.workspace }}/build/default" >> "$GITHUB_OUTPUT"
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -95,7 +95,7 @@ jobs:
     - name: Configure ASan build
       if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
       run: >
-        cmake -B ${{ github.workspace }}/build-asan
+        cmake -B ${{ github.workspace }}/build/asan
         -DCMAKE_C_COMPILER=gcc
         -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer"
@@ -104,13 +104,13 @@ jobs:
 
     - name: Build ASan
       if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
-      run: cmake --build ${{ github.workspace }}/build-asan
+      run: cmake --build ${{ github.workspace }}/build/asan
 
     - name: Run ASan tests
       if: matrix.c_compiler == 'gcc' && matrix.build_type == 'Debug'
       run: |
         failed=''; total=0; passed=0
-        for t in $(find ${{ github.workspace }}/build-asan/tests \
+        for t in $(find ${{ github.workspace }}/build/asan/tests \
                         -maxdepth 1 -name 'test_*' -executable -type f | sort); do
           name=$(basename "$t"); total=$((total + 1))
           printf '\n=== asan: %s ===\n' "$name"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # CMake version and project name
 cmake_minimum_required(VERSION 3.24...4.3.2)
 set(CUTIL_LIBRARY "cutil")
+# Export set name is derived from the library name; all install(TARGETS EXPORT ...) and
+# install(EXPORT ...) blocks use this variable to ensure the name stays in sync.
+set(CUTIL_EXPORT_SET "${CUTIL_LIBRARY}-targets")
 project("${CUTIL_LIBRARY}" LANGUAGES C)
 
 # Set C standard
@@ -31,21 +34,29 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     string(APPEND CMAKE_C_FLAGS_DEBUG " -O0")
     string(APPEND CMAKE_C_FLAGS_DEBUG " -g")
     string(APPEND CMAKE_C_FLAGS_DEBUG " -Werror")
+    # RelWithDebInfo intentionally uses -O2, not -O3: CMAKE_C_FLAGS_RELEASE is expanded at this
+    # point (before -O3 is appended below), so RelWithDebInfo inherits all Release flags except -O3.
     string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " ${CMAKE_C_FLAGS_RELEASE}")
     string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -O2")
     string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -g")
     string(APPEND CMAKE_C_FLAGS_RELEASE " -O3")
 endif ()
 
-# Set output path for binaries
-set(CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/bin")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+# Set output path for binaries. CMAKE_BINARY_DIR is read-only after project(); use CUTIL_OUTPUT_DIR
+# for the artefact path.
+set(CUTIL_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CUTIL_OUTPUT_DIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CUTIL_OUTPUT_DIR}")
 
 # Options
 option(CUTIL_BUILD_SHARED_AND_STATIC_LIBS "Build both shared and static libraries" ON)
+option(ENABLE_TESTS "Build and enable unit tests" OFF)
 
 # Utility variables
+
+# When CUTIL_BUILD_SHARED_AND_STATIC_LIBS is ON (default), both flags are always set regardless of
+# BUILD_SHARED_LIBS; the OR-conditions below are unreachable while the combined option is ON. They
+# serve as a fallback when that option is explicitly disabled.
 if (CUTIL_BUILD_SHARED_AND_STATIC_LIBS OR BUILD_SHARED_LIBS)
     set(CUTIL_BUILD_SHARED_LIB TRUE)
 endif ()
@@ -69,8 +80,13 @@ set(CUTIL_COMPONENT_DATA data)
 set(CUTIL_LIBRARY_DATA "${CUTIL_LIBRARY}${CUTIL_COMPONENT_DATA}")
 add_subdirectory(lib/data)
 
-# Add the tests directory
+# Include CTest support; also invokes enable_testing() internally.
 include(CTest)
+
+if (ENABLE_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif ()
 
 # Configure the uninstaller
 configure_file(cmake/cmake_uninstall.cmake.in cmake_uninstall.cmake @ONLY)
@@ -81,9 +97,6 @@ add_custom_target(
     COMMENT "Uninstalling..."
 )
 
-# Include GNUInstallDirs for proper install destinations
-include(GNUInstallDirs)
-
 # Generate config file for find_package()
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
@@ -91,10 +104,15 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CUTIL_LIBRARY}"
 )
 
-# Generate and install export configuration
+# Install the generated wrapper config file
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CUTIL_LIBRARY}Config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CUTIL_LIBRARY}"
+)
+
+# Export targets to <CUTIL_EXPORT_SET>.cmake (referenced via include() from cutilConfig.cmake.in)
 install(
-    EXPORT "${CUTIL_LIBRARY}-targets"
-    FILE "${CUTIL_LIBRARY}Config.cmake"
+    EXPORT "${CUTIL_EXPORT_SET}"
+    FILE "${CUTIL_EXPORT_SET}.cmake"
     NAMESPACE "${CUTIL_LIBRARY}::"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${CUTIL_LIBRARY}"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,12 @@ set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/${CUTIL_LIBRARY}")
 
 # Add core library
 set(CUTIL_COMPONENT_CORE "core")
-set(CUTIL_LIBRARY_CORE "${CUTIL_COMPONENT_CORE}")
+set(CUTIL_LIBRARY_CORE "${CUTIL_LIBRARY}${CUTIL_COMPONENT_CORE}")
 add_subdirectory(lib/core)
 
 # Add data library
 set(CUTIL_COMPONENT_DATA data)
-set(CUTIL_LIBRARY_DATA "${CUTIL_COMPONENT_DATA}")
+set(CUTIL_LIBRARY_DATA "${CUTIL_LIBRARY}${CUTIL_COMPONENT_DATA}")
 add_subdirectory(lib/data)
 
 # Add the tests directory

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,4 +1,0 @@
-if(ENABLE_TESTS)
-    enable_testing()
-    add_subdirectory(tests)
-endif()

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -23,7 +23,7 @@ set(SOURCE_FILES_CORE
 if (CUTIL_BUILD_SHARED_LIB)
     add_library("${CUTIL_LIBRARY_CORE}" SHARED "${SOURCE_FILES_CORE}")
     set_target_properties(
-        "${CUTIL_LIBRARY_CORE}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY}${CUTIL_LIBRARY_CORE}"
+        "${CUTIL_LIBRARY_CORE}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_CORE}"
                                            PREFIX "lib"
     )
 
@@ -32,8 +32,9 @@ if (CUTIL_BUILD_SHARED_LIB)
     endif ()
 
     target_include_directories(
-        "${CUTIL_LIBRARY_CORE}" PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/include>"
-                                       "$<INSTALL_INTERFACE:include>"
+        "${CUTIL_LIBRARY_CORE}"
+        PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
+               "$<INSTALL_INTERFACE:include>"
     )
 
     install(
@@ -62,8 +63,9 @@ if (CUTIL_BUILD_STATIC_LIB)
     endif ()
 
     target_include_directories(
-        "${CUTIL_LIBRARY_CORE}-static" PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/include>"
-                                              "$<INSTALL_INTERFACE:include>"
+        "${CUTIL_LIBRARY_CORE}-static"
+        PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
+               "$<INSTALL_INTERFACE:include>"
     )
 
     install(
@@ -79,7 +81,7 @@ endif ()
 
 # Install headers
 install(
-    DIRECTORY "${CMAKE_SOURCE_DIR}/lib/include/cutil/${CUTIL_COMPONENT_CORE}"
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include/cutil/${CUTIL_COMPONENT_CORE}"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     FILES_MATCHING
     PATTERN "*.h"

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -23,8 +23,7 @@ set(SOURCE_FILES_CORE
 if (CUTIL_BUILD_SHARED_LIB)
     add_library("${CUTIL_LIBRARY_CORE}" SHARED "${SOURCE_FILES_CORE}")
     set_target_properties(
-        "${CUTIL_LIBRARY_CORE}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_CORE}"
-                                           PREFIX "lib"
+        "${CUTIL_LIBRARY_CORE}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_CORE}" PREFIX "lib"
     )
 
     if (NOT WIN32)
@@ -33,19 +32,20 @@ if (CUTIL_BUILD_SHARED_LIB)
 
     target_include_directories(
         "${CUTIL_LIBRARY_CORE}"
+        # The relative path is intentional: using ${CMAKE_SOURCE_DIR} would break when cutil is
+        # consumed as a CMake subdirectory in another project.
         PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
                "$<INSTALL_INTERFACE:include>"
     )
 
     install(
         TARGETS "${CUTIL_LIBRARY_CORE}"
-        EXPORT "${CUTIL_LIBRARY}-targets"
+        EXPORT "${CUTIL_EXPORT_SET}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         INCLUDES
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        NAMESPACE "${CUTIL_LIBRARY}::"
         COMPONENT "${CUTIL_COMPONENT_CORE}"
     )
 endif ()
@@ -54,8 +54,7 @@ endif ()
 if (CUTIL_BUILD_STATIC_LIB)
     add_library("${CUTIL_LIBRARY_CORE}-static" STATIC "${SOURCE_FILES_CORE}")
     set_target_properties(
-        "${CUTIL_LIBRARY_CORE}-static"
-        PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY}${CUTIL_LIBRARY_CORE}" PREFIX "lib"
+        "${CUTIL_LIBRARY_CORE}-static" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_CORE}" PREFIX "lib"
     )
 
     if (NOT WIN32)
@@ -64,17 +63,18 @@ if (CUTIL_BUILD_STATIC_LIB)
 
     target_include_directories(
         "${CUTIL_LIBRARY_CORE}-static"
+        # The relative path is intentional: using ${CMAKE_SOURCE_DIR} would break when cutil is
+        # consumed as a CMake subdirectory in another project.
         PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
                "$<INSTALL_INTERFACE:include>"
     )
 
     install(
         TARGETS "${CUTIL_LIBRARY_CORE}-static"
-        EXPORT "${CUTIL_LIBRARY}-targets"
+        EXPORT "${CUTIL_EXPORT_SET}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         INCLUDES
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        NAMESPACE "${CUTIL_LIBRARY}::"
         COMPONENT "${CUTIL_COMPONENT_CORE}"
     )
 endif ()

--- a/lib/data/CMakeLists.txt
+++ b/lib/data/CMakeLists.txt
@@ -25,8 +25,7 @@ set(SOURCE_FILES_DATA
 if (CUTIL_BUILD_SHARED_LIB)
     add_library("${CUTIL_LIBRARY_DATA}" SHARED "${SOURCE_FILES_DATA}")
     set_target_properties(
-        "${CUTIL_LIBRARY_DATA}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_DATA}"
-                                           PREFIX "lib"
+        "${CUTIL_LIBRARY_DATA}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_DATA}" PREFIX "lib"
     )
 
     if (NOT WIN32)
@@ -37,19 +36,20 @@ if (CUTIL_BUILD_SHARED_LIB)
 
     target_include_directories(
         "${CUTIL_LIBRARY_DATA}"
+        # The relative path is intentional: using ${CMAKE_SOURCE_DIR} would break when cutil is
+        # consumed as a CMake subdirectory in another project.
         PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
                "$<INSTALL_INTERFACE:include>"
     )
 
     install(
         TARGETS "${CUTIL_LIBRARY_DATA}"
-        EXPORT "${CUTIL_LIBRARY}-targets"
+        EXPORT "${CUTIL_EXPORT_SET}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         INCLUDES
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        NAMESPACE "${CUTIL_LIBRARY}::"
         COMPONENT "${CUTIL_COMPONENT_DATA}"
     )
 endif ()
@@ -58,8 +58,7 @@ endif ()
 if (CUTIL_BUILD_STATIC_LIB)
     add_library("${CUTIL_LIBRARY_DATA}-static" STATIC "${SOURCE_FILES_DATA}")
     set_target_properties(
-        "${CUTIL_LIBRARY_DATA}-static"
-        PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY}${CUTIL_LIBRARY_DATA}" PREFIX "lib"
+        "${CUTIL_LIBRARY_DATA}-static" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_DATA}" PREFIX "lib"
     )
 
     if (NOT WIN32)
@@ -70,17 +69,18 @@ if (CUTIL_BUILD_STATIC_LIB)
 
     target_include_directories(
         "${CUTIL_LIBRARY_DATA}-static"
+        # The relative path is intentional: using ${CMAKE_SOURCE_DIR} would break when cutil is
+        # consumed as a CMake subdirectory in another project.
         PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
                "$<INSTALL_INTERFACE:include>"
     )
 
     install(
         TARGETS "${CUTIL_LIBRARY_DATA}-static"
-        EXPORT "${CUTIL_LIBRARY}-targets"
+        EXPORT "${CUTIL_EXPORT_SET}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         INCLUDES
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        NAMESPACE "${CUTIL_LIBRARY}::"
         COMPONENT "${CUTIL_COMPONENT_DATA}"
     )
 endif ()

--- a/lib/data/CMakeLists.txt
+++ b/lib/data/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCE_FILES_DATA
 if (CUTIL_BUILD_SHARED_LIB)
     add_library("${CUTIL_LIBRARY_DATA}" SHARED "${SOURCE_FILES_DATA}")
     set_target_properties(
-        "${CUTIL_LIBRARY_DATA}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY}${CUTIL_LIBRARY_DATA}"
+        "${CUTIL_LIBRARY_DATA}" PROPERTIES OUTPUT_NAME "${CUTIL_LIBRARY_DATA}"
                                            PREFIX "lib"
     )
 
@@ -36,8 +36,9 @@ if (CUTIL_BUILD_SHARED_LIB)
     target_link_libraries("${CUTIL_LIBRARY_DATA}" PUBLIC "${CUTIL_LIBRARY_CORE}")
 
     target_include_directories(
-        "${CUTIL_LIBRARY_DATA}" PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/include>"
-                                       "$<INSTALL_INTERFACE:include>"
+        "${CUTIL_LIBRARY_DATA}"
+        PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
+               "$<INSTALL_INTERFACE:include>"
     )
 
     install(
@@ -68,8 +69,9 @@ if (CUTIL_BUILD_STATIC_LIB)
     target_link_libraries("${CUTIL_LIBRARY_DATA}-static" PUBLIC "${CUTIL_LIBRARY_CORE}")
 
     target_include_directories(
-        "${CUTIL_LIBRARY_DATA}-static" PUBLIC "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/include>"
-                                              "$<INSTALL_INTERFACE:include>"
+        "${CUTIL_LIBRARY_DATA}-static"
+        PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include>"
+               "$<INSTALL_INTERFACE:include>"
     )
 
     install(
@@ -85,7 +87,7 @@ endif ()
 
 # Install headers
 install(
-    DIRECTORY "${CMAKE_SOURCE_DIR}/lib/include/cutil/${CUTIL_COMPONENT_DATA}"
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../lib/include/cutil/${CUTIL_COMPONENT_DATA}"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     FILES_MATCHING
     PATTERN "*.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,28 @@
-project("CUTIL_TESTS" LANGUAGES C CXX)
+# CXX is only needed for test_cpp.cpp targets; enable it narrowly here rather than in the
+# root project (which is C-only by design).
+enable_language(CXX)
 
 # Derive test name: test_<dir_underscored>_<stem> e.g. data/generic/test_array.c ->
 # test_data_generic_array
-function (DERIVE_TEST_NAME test_name test_source)
-    get_filename_component(TEST_DIR "${test_source}" DIRECTORY)
-    get_filename_component(TEST_BASENAME "${test_source}" NAME_WE)
+function (DERIVE_TEST_NAME TEST_NAME TEST_SOURCE)
+    get_filename_component(TEST_DIR "${TEST_SOURCE}" DIRECTORY)
+    get_filename_component(TEST_BASENAME "${TEST_SOURCE}" NAME_WE)
     string(REPLACE "/" "_" TEST_DIR_UNDERSCORED "${TEST_DIR}")
     string(REGEX REPLACE "^test_" "" TEST_STEM "${TEST_BASENAME}")
-    set(${test_name} "test_${TEST_DIR_UNDERSCORED}_${TEST_STEM}" PARENT_SCOPE)
+    set(${TEST_NAME} "test_${TEST_DIR_UNDERSCORED}_${TEST_STEM}" PARENT_SCOPE)
 endfunction ()
 
-# Create C test executables
-function (CREATE_C_TESTS source_files cutil_modules)
+# Create C test executables; appends created target names to the variable named by OUT_TARGETS.
+function (CREATE_C_TESTS OUT_TARGETS SOURCE_FILES CUTIL_MODULES)
+    set(_local_targets "${${OUT_TARGETS}}")
     # Loop over all C tests
-    foreach (TEST_SOURCE IN LISTS ${source_files})
+    foreach (TEST_SOURCE IN LISTS ${SOURCE_FILES})
         derive_test_name(TEST_NAME ${TEST_SOURCE})
 
         # Add tests and executables
         add_executable("${TEST_NAME}" "${TEST_SOURCE}")
         add_test(NAME "${TEST_NAME}" COMMAND "${TEST_NAME}")
-        list(APPEND CUTIL_TEST_TARGETS "${TEST_NAME}")
+        list(APPEND _local_targets "${TEST_NAME}")
 
         # Add resources directory as a macro
         target_compile_definitions(
@@ -30,31 +33,34 @@ function (CREATE_C_TESTS source_files cutil_modules)
         target_link_libraries("${TEST_NAME}" PRIVATE unity)
 
         # Link and include cutil modules
-        foreach (CUTIL_MODULE IN LISTS ${cutil_modules})
+        foreach (CUTIL_MODULE IN LISTS ${CUTIL_MODULES})
             target_link_libraries("${TEST_NAME}" PRIVATE "${CUTIL_MODULE}")
         endforeach ()
 
         # Enable Unity double-comparison macros
         target_compile_definitions("${TEST_NAME}" PRIVATE UNITY_INCLUDE_DOUBLE)
     endforeach ()
+    set(${OUT_TARGETS} ${_local_targets} PARENT_SCOPE)
 endfunction ()
 
-# Create C++ test executables
-function (CREATE_CXX_TESTS source_files cutil_modules)
+# Create C++ test executables; appends created target names to the variable named by OUT_TARGETS.
+function (CREATE_CXX_TESTS OUT_TARGETS SOURCE_FILES CUTIL_MODULES)
+    set(_local_targets "${${OUT_TARGETS}}")
     # Loop over all C++ tests
-    foreach (TEST_SOURCE IN LISTS ${source_files})
+    foreach (TEST_SOURCE IN LISTS ${SOURCE_FILES})
         derive_test_name(TEST_NAME ${TEST_SOURCE})
 
         # Add tests and executables
         add_executable("${TEST_NAME}" "${TEST_SOURCE}")
         add_test(NAME "${TEST_NAME}" COMMAND "${TEST_NAME}")
-        list(APPEND CUTIL_TEST_TARGETS "${TEST_NAME}")
+        list(APPEND _local_targets "${TEST_NAME}")
 
         # Link and include cutil modules
-        foreach (CUTIL_MODULE IN LISTS ${cutil_modules})
+        foreach (CUTIL_MODULE IN LISTS ${CUTIL_MODULES})
             target_link_libraries("${TEST_NAME}" PRIVATE "${CUTIL_MODULE}")
         endforeach ()
     endforeach ()
+    set(${OUT_TARGETS} ${_local_targets} PARENT_SCOPE)
 endfunction ()
 
 # Set additional compiler flags (UNIX)
@@ -119,8 +125,8 @@ set(C_TEST_SOURCES_DATA
 set(MODULE_DEPENDENCIES_CORE ${CUTIL_LIB_CORE})
 set(MODULE_DEPENDENCIES_DATA ${CUTIL_LIB_CORE} ${CUTIL_LIB_DATA})
 
-create_c_tests(C_TEST_SOURCES_CORE MODULE_DEPENDENCIES_CORE)
-create_c_tests(C_TEST_SOURCES_DATA MODULE_DEPENDENCIES_DATA)
+create_c_tests(CUTIL_TEST_TARGETS C_TEST_SOURCES_CORE MODULE_DEPENDENCIES_CORE)
+create_c_tests(CUTIL_TEST_TARGETS C_TEST_SOURCES_DATA MODULE_DEPENDENCIES_DATA)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
@@ -131,8 +137,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CXX_TEST_SOURCES_CORE core/test_cpp.cpp)
 set(CXX_TEST_SOURCES_DATA data/test_cpp.cpp)
 
-create_cxx_tests(CXX_TEST_SOURCES_CORE MODULE_DEPENDENCIES_CORE)
-create_cxx_tests(CXX_TEST_SOURCES_DATA MODULE_DEPENDENCIES_DATA)
+create_cxx_tests(CUTIL_TEST_TARGETS CXX_TEST_SOURCES_CORE MODULE_DEPENDENCIES_CORE)
+create_cxx_tests(CUTIL_TEST_TARGETS CXX_TEST_SOURCES_DATA MODULE_DEPENDENCIES_DATA)
 
 # Expose targets to set output directory
 set(CUTIL_TEST_TARGETS "${CUTIL_TEST_TARGETS}" CACHE INTERNAL "List of cutil test targets" FORCE)
@@ -143,7 +149,7 @@ if (NOT TARGET cutil-check)
         cutil-check
         COMMAND "${CMAKE_CTEST_COMMAND}" "--output-on-failure"
         DEPENDS "${CUTIL_TEST_TARGETS}"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         COMMENT "Running cutil tests"
     )
 endif ()


### PR DESCRIPTION
# Summary
Improve CMake setup.

# Changes
- Rename `cutil` modules in CMake files
- Adjust build paths to support inclusion as a submodule
- Clean up / harden CMake files
- Adjust build paths in CI pipeline